### PR TITLE
Update download.sh

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -21,7 +21,7 @@ fi
 # correctly.
 if [[ ${#VERSION} -ge 4 ]] && [[ $VERSION == *.0 ]]; then
     echo "Version is *.0, correcting version script";
-    VERSION=TRIMMED_V;
+    VERSION=$TRIMMED_V;
 fi
 
 echo "Downloading relevant files from linux git repsoitory...";


### PR DESCRIPTION
in commit 19501c1470a0b119d1472348293a65f54eda068c reassigning VERSION to TRIMMED_V doesn't call TRIMMED_V as a variable and therefore sets the string to be "TRIMMED_V" which causes an error 404 when trying to download from git.kernel.org.