### PR TITLE
Support kernel versions > 6.0

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -11,7 +11,7 @@ DO_ACCEL=true
 # Fix for issue #3, `dual_accel_detect.h` only got added in kernel v5.14, if we are less than that set the flag false so we don't
 # attempt to download `dual_accel_detect.h`.
 IFS='.' read -ra BROKEN_V <<< "$TRIMMED_V";
-if [[ ${BROKEN_V[0]} -le 4 ]] ||  ([[ ${BROKEN_V[0]} -ge 5 ]] && [[ ${BROKEN_V[1]} -le 13 ]]); then
+if [[ ${BROKEN_V[0]} -le 5 ]] && [[ ${BROKEN_V[1]} -le 13 ]]; then
     echo "Kernel version is < 5.14, dual_accel_detect.h download is not required";
     DO_ACCEL=false
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -10,8 +10,8 @@ DO_ACCEL=true
 
 # Fix for issue #3, `dual_accel_detect.h` only got added in kernel v5.14, if we are less than that set the flag false so we don't
 # attempt to download `dual_accel_detect.h`.
-IFS='.' read -ra BROKEN_V <<< "$TRIMMED_V";
-if [[ ${BROKEN_V[0]} -le 5 ]] && [[ ${BROKEN_V[1]} -le 13 ]]; then
+printf '%s\n' "$VERSION" "5.14" | sort -CV;
+if [ "$?" -ne 1 ]; then
     echo "Kernel version is < 5.14, dual_accel_detect.h download is not required";
     DO_ACCEL=false
 fi

--- a/scripts/version_check.sh
+++ b/scripts/version_check.sh
@@ -1,13 +1,12 @@
-VERSION=$(uname -r);
-VERSION="${VERSION%%-*}";
-TRIMMED_V="${VERSION::-2}";
+#!/usr/bin/env bash
+
+VERSION="$(uname -r)"
 
 # Fix for issue #3, the lapmode sensor only got added in kernel v5.9, if we are less than that this script will do nothing, as this
 # kernel module can't read that value anyway.
-IFS='.' read -ra BROKEN_V <<< "$TRIMMED_V";
-if [[ ${BROKEN_V[0]} -le 5 ]] && [[ ${BROKEN_V[1]} -le 8 ]]; then
-    echo "Kernel version is < 5.9, this dkms modification will do nothing for you sorry! Please consider updating your kernel.";
-    exit 1;
-fi
+printf '%s\n' "5.9" "$VERSION" | sort -CV || (
+  echo "The kernel version is < 5.9. This dkms modification will do nothing for you, sorry! Please consider updating your kernel."
+  exit 1
+)
 
-exit 0;
+exit 0

--- a/scripts/version_check.sh
+++ b/scripts/version_check.sh
@@ -5,7 +5,7 @@ TRIMMED_V="${VERSION::-2}";
 # Fix for issue #3, the lapmode sensor only got added in kernel v5.9, if we are less than that this script will do nothing, as this
 # kernel module can't read that value anyway.
 IFS='.' read -ra BROKEN_V <<< "$TRIMMED_V";
-if [[ ${BROKEN_V[0]} -le 4 ]] ||  ([[ ${BROKEN_V[0]} -ge 5 ]] && [[ ${BROKEN_V[1]} -le 8 ]]); then
+if [[ ${BROKEN_V[0]} -le 5 ]] && [[ ${BROKEN_V[1]} -le 8 ]]; then
     echo "Kernel version is < 5.9, this dkms modification will do nothing for you sorry! Please consider updating your kernel.";
     exit 1;
 fi


### PR DESCRIPTION
Both if statement in update.sh and version_check.sh fail for kernel versions greater than 6.0. The statements have been fixed to only fail when the version number is smaller than 5.14 (in update.sh) or 5.9 (in version_check.sh) respectively.