### PR TITLE
Change "*state=false" to  "lap_state=false"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Upon running `sudo modinfo thinkpad_acpi`, you should see the version is set to:
 
 ```bash
 version: 420.26
-singer: DKMS module signing key
+signer: DKMS module signing key
 ```
 
 Congratulations! You've patched your kernel. The lap-mode sensor is now disabled.

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -44,10 +44,16 @@ fi
 echo "Applying modifications to thinkpad_acpi.c...";
 
 # Apply modifications to thinkpad_acpi.c
-# disable lapmode sensor
-sed -i 's/*state = output \& BIT(DYTC_GET_LAPMODE_BIT) ? true : false/*state = output \& BIT(DYTC_GET_LAPMODE_BIT) ? false : false/' thinkpad_acpi.c;
+# Disable lap_state
+sed -i 's/if (lap_state != state)/if (lap_state != false)/' thinkpad_acpi.c;
 if [ $? -ne 0 ]; then
-    echo "Failed to disable the lapmode sensor for thinkpad_acpi.c";
+    echo "Failed to disable lap_state set command for thinkpad_acpi.c";
+    exit 1;
+fi
+
+sed -i 's/lap_state = state/lap_state = false/' thinkpad_acpi.c;
+if [ $? -ne 0 ]; then
+    echo "Failed to disable lap_state set command for thinkpad_acpi.c";
     exit 1;
 fi
 


### PR DESCRIPTION
The original method "state = false" didn't work for my ThinkPad T14 Gen1 with Ubuntu 22.04LTS, so I change it to make sure that the "lap_state" always be false.
Guess it's because the "lap_state" is a global variable, so may be modified elsewhere, however, its refresh logic is still in thinkpadacpi.c. So we can keep lap_state as false to enure that the profile will not be convert due to this var. 